### PR TITLE
Fix duplicate save method

### DIFF
--- a/utils/add_nms.py
+++ b/utils/add_nms.py
@@ -142,14 +142,3 @@ class RegisterNMS(object):
 
         self.infer()
 
-    def save(self, output_path):
-        """
-        Save the ONNX model to the given location.
-        Args:
-            output_path: Path pointing to the location where to write
-                out the updated ONNX model.
-        """
-        self.graph.cleanup().toposort()
-        model = gs.export_onnx(self.graph)
-        onnx.save(model, output_path)
-        LOGGER.info(f"Saved ONNX model to {output_path}")


### PR DESCRIPTION
## Summary
- clean up `RegisterNMS` helper by removing a duplicate `save` method

## Testing
- `python -m py_compile $(find . -name '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6840069e51948332adbe32fbb4a97422